### PR TITLE
Incorporate `git describe` into schema version

### DIFF
--- a/generators/google-sheets/sheet2linkml/cli.py
+++ b/generators/google-sheets/sheet2linkml/cli.py
@@ -5,6 +5,8 @@ A script for converting Google Sheets to a LinkML model.
 
 import sys
 import os
+import re
+import subprocess
 import logging
 import logging.config
 from sheet2linkml import config
@@ -36,9 +38,14 @@ def main(filter_entity, logging_config):
     # Arbitrarily set a CRDC-H root URI.
     crdch_root = "https://example.org/ccdh"
 
-    # Load the Google Sheet model.
+    # Load the Google Sheet model and add the development version number.
     model = GSheetModel(google_api_credentials, google_sheet_id)
     logging.info(f"Google Sheet loaded: {model}")
+
+    # Determine the development version number. We can get this from git-describe.
+    git_describe_result = subprocess.run(['git', 'describe', '--long', '--dirty'], capture_output=True)
+    if git_describe_result.returncode == 0:
+        model.development_version = re.sub('[^a-zA-Z0-9.\\-]', '_', git_describe_result.stdout.decode('utf8').strip())
 
     # We have two operating modes:
     # 1. If a `--filter-entity "<Entity Name>"` is specified on the command line,

--- a/generators/google-sheets/sheet2linkml/source/gsheetmodel/gsheetmodel.py
+++ b/generators/google-sheets/sheet2linkml/source/gsheetmodel/gsheetmodel.py
@@ -48,6 +48,12 @@ class GSheetModel(ModelElement):
         )
         self.sheet = self.client.open_by_key(google_sheet_id)
 
+        # TODO: at some point, we should read the version number from the Google Sheets document... somehow.
+        self.version = None
+
+        # Set a `development version`. This is initially None, but if set, we add this to the metadata we emit.
+        self.development_version = None
+
     def entity_worksheets(self) -> list[EntityWorksheet]:
         """
         A list of worksheets available in this model.
@@ -132,8 +138,6 @@ class GSheetModel(ModelElement):
 
         # Set up general metadata.
         schema: SchemaDefinition = SchemaDefinition(name="CRDC-H", id=f"{root_uri}")
-        schema.version = "v0"  # TODO: Replace with a version.
-        schema.license = "https://creativecommons.org/publicdomain/zero/1.0/"
         schema.prefixes = {
             "linkml": "https://w3id.org/linkml/",
             "ccdh": f"{root_uri}/",
@@ -143,10 +147,16 @@ class GSheetModel(ModelElement):
         schema.imports = [
             'linkml:types'
         ]
-
         schema.default_prefix = "ccdh"
-        schema.notes.append(f"derived from {self.to_markdown()}")
+
+        schema.license = "https://creativecommons.org/publicdomain/zero/1.0/"
+        schema.notes.append(f"Derived from {self.to_markdown()}")
         schema.generation_date = datetime.now().isoformat()
+
+        if self.version:
+            schema.version = self.version
+        elif self.development_version:
+            schema.version = self.development_version
 
         # Generate all the entities.
         schema.classes = {entity.name: entity.as_linkml(root_uri) for entity in self.entities()}


### PR DESCRIPTION
This PR adds support for using the current Git commit as the model version number, by using the command line [`git describe`](https://git-scm.com/docs/git-describe) command. Eventually we will override this by reading the version number from the Google Sheet (probably from the Changelog in there), but for now this should help figure out which version of the model we're looking at.