### PR TITLE
Github action to run `tox` tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,56 @@
+# Built from:
+# https://docs.github.com/en/actions/guides/building-and-testing-python
+
+name: Run tests
+
+  on: [push, pull_request]
+  jobs:
+    build:
+
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python-version: [3.6, 3.7, 3.8, 3.9]
+
+      steps:
+
+        #----------------------------------------------
+        #       check-out repo and set-up python
+        #----------------------------------------------
+        - name: Check out repository
+          uses: actions/checkout@v2
+
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+
+        #----------------------------------------------
+        #          install & configure tox
+        #----------------------------------------------
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pipenv tox
+
+        #----------------------------------------------
+        #       load cached pipenv if cache exists
+        #----------------------------------------------
+        - name: Load cached venv
+          id: cached-poetry-dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.local/share/virtualenvs
+            key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+
+        #----------------------------------------------
+        # install dependencies if cache does not exist
+        #----------------------------------------------
+        - name: Install dependencies
+          if: steps.cache-pipenv.outputs.cache-hit != 'true'
+          run: pipenv install --deploy --dev
+
+        #----------------------------------------------
+        #             run tests with tox
+        #----------------------------------------------
+        - name: Run tox tests
+          run: pipenv run tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -54,4 +54,4 @@ jobs:
       #             run tests with tox
       #----------------------------------------------
       - name: Run tox tests
-        run: pipenv run tox
+        run: pipenv run tox4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,54 +3,55 @@
 
 name: Run tests
 
-  on: [push, pull_request]
-  jobs:
-    build:
+on: [push, pull_request]
 
-      runs-on: ubuntu-latest
-      strategy:
-        matrix:
-          python-version: [3.6, 3.7, 3.8, 3.9]
+jobs:
+  build:
 
-      steps:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
-        #----------------------------------------------
-        #       check-out repo and set-up python
-        #----------------------------------------------
-        - name: Check out repository
-          uses: actions/checkout@v2
+    steps:
 
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v2
-          with:
-            python-version: ${{ matrix.python-version }}
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v2
 
-        #----------------------------------------------
-        #          install & configure tox
-        #----------------------------------------------
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pipenv tox
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-        #----------------------------------------------
-        #       load cached pipenv if cache exists
-        #----------------------------------------------
-        - name: Load cached venv
-          id: cached-poetry-dependencies
-          uses: actions/cache@v2
-          with:
-            path: ~/.local/share/virtualenvs
-            key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+      #----------------------------------------------
+      #          install & configure tox
+      #----------------------------------------------
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pipenv tox
 
-        #----------------------------------------------
-        # install dependencies if cache does not exist
-        #----------------------------------------------
-        - name: Install dependencies
-          if: steps.cache-pipenv.outputs.cache-hit != 'true'
-          run: pipenv install --deploy --dev
+      #----------------------------------------------
+      #       load cached pipenv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
 
-        #----------------------------------------------
-        #             run tests with tox
-        #----------------------------------------------
-        - name: Run tox tests
-          run: pipenv run tox
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cache-pipenv.outputs.cache-hit != 'true'
+        run: pipenv install --deploy --dev
+
+      #----------------------------------------------
+      #             run tests with tox
+      #----------------------------------------------
+      - name: Run tox tests
+        run: pipenv run tox


### PR DESCRIPTION
This PR seeks to address issue #99, by adding a Github Actions [workflow](https://github.com/cancerDHC/ccdhmodel/blob/spatil/gh-action/.github/workflows/tox.yml) that has a step to run the below command as indicated in the issue:

```
$ pipenv run tox4
```