### PR TITLE
Fix PyPI package generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,5 +325,3 @@ pypi:
 	rm -f dist/*
 	$(RUN) python setup.py sdist bdist_wheel
 	$(RUN) twine upload dist/*
-	git commit -am 'post twine push'
-	git push --tags

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,12 @@ keywords =
 
 [options]
 include_package_data = True
-packages = crdch_model
+package_dir=
+    =crdch_model
+packages=find:
+
+[options.packages.find]
+where=crdch_model
 
 [files]
 data-files = model = model/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,11 +43,9 @@ keywords =
 
 [options]
 include_package_data = True
+packages = crdch_model
 
 [files]
-packages =
-    crdch_model
-
 data-files = model = model/*
     crdch_model/graphql = crdch_model/graphql/*
     crdch_model/jsonschema = crdch_model/jsonschema/*

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ if sys.version_info < (3, 7, 0):
     sys.exit(1)
 
 setup(
-    version = '1.1'
+    version = '1.1.1'
 )


### PR DESCRIPTION
I found a bug in the PyPI package generation -- the generated .whl and .tar.gz files didn't actually contain the crdch_model.py program. Luckily, it was a pretty easy fix, and [crdch-model v1.1.1](https://pypi.org/project/crdch-model/1.1.1/) contains the files and seems to work with the Example Data Workflow.

I don't think the data files are being included, either; there's some example syntax in https://setuptools.pypa.io/en/latest/userguide/declarative_config.html that might help.

Closes #69.