### PR TITLE
fix importing of `crdch_model` dataclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Model changes
   * Renamed `ccdh` to `crdch` in the model.
   * Separated CodeableConcepts from the enums upon which they are based.
+    * Specifically, each CodeableConcept now uses the LinkML `values_from` field to store a reference to the enum
+      from which terms are expected to be used. See [PR #115](https://github.com/cancerDHC/ccdhmodel/pull/115) for
+      details.
   * Updated terminologies to the latest from the Terminology Server.
   * Minor changes made during the CCDH Pilot (August to September 2021).
 * LinkML representation

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,11 +43,14 @@ keywords =
 
 [options]
 include_package_data = True
+package_dir=
+    =crdch_model
+packages=find:
+
+[options.packages.find]
+where=crdch_model
 
 [files]
-packages =
-    crdch_model
-
 data-files = model = model/*
     crdch_model/graphql = crdch_model/graphql/*
     crdch_model/jsonschema = crdch_model/jsonschema/*

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ if sys.version_info < (3, 7, 0):
     sys.exit(1)
 
 setup(
-    version = '0.4.3-dev'
+    version = '1.1'
 )


### PR DESCRIPTION
Allow the easy importing of the `crdch_model` dataclass from the `crdch_model` subpackage.

Try the following to confirm it works as expected:

```python
from crdch_model import BodySite
```